### PR TITLE
fix serverOptions types exports (#22)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
       "import": "./dist/module.mjs",
       "require": "./dist/module.cjs"
     },
-    "./dist/runtime/serverOptions": "./dist/runtime/serverOptions/index.mjs"
+    "./dist/runtime/serverOptions": {
+      "import": "./dist/runtime/serverOptions/index.mjs",
+      "types": "./dist/runtime/serverOptions/index.d.ts"
+    }
   },
   "main": "./dist/module.cjs",
   "types": "./dist/types.d.ts",


### PR DESCRIPTION
Fix issue #22 happen since Nuxt 3.10 with the activation of [Bundler Module Resolution](https://nuxt.com/blog/v3-10#bundler-module-resolution)