### PR TITLE
fix: adopt forward-compatible approach to `builder:watch`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1,7 +1,7 @@
 import { fileURLToPath } from 'url'
 import type { Types } from '@graphql-codegen/plugin-helpers'
 import { type SchemaASTConfig } from '@graphql-codegen/schema-ast'
-import { resolve } from 'pathe'
+import { relative, resolve } from 'pathe'
 import { defu } from 'defu'
 import { type BirpcGroup } from 'birpc'
 import {
@@ -474,6 +474,7 @@ declare module '#graphql-documents' {
       })
       nuxt.hook('nitro:build:before', (nitro) => {
         nuxt.hook('builder:watch', async (_event, path) => {
+          path = relative(nuxt.options.srcDir, resolve(nuxt.options.srcDir, path))
           // We only care about GraphQL files.
           if (!path.match(/\.(gql|graphql)$/)) {
             return


### PR DESCRIPTION
We are planning to move to [emitting absolute paths in `builder:watch` in Nuxt v4](https://github.com/nuxt/nuxt/issues/25339). You can see a little more about the history in the PR linked in that issue.

This PR is an attempt to use a forward/backward compatible approach, namely resolving the path to ensure it's absolute, then making it relative so your existing code will continue to work.

This should be safe to merge as is, but do let me know if you have any concerns about this approach.

