### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Expose GraphQL queries and mutations as fully typed API routes.
 ## Install
 
 ```bash
-npm install --save nuxt-graphql-middleware
+npx nuxi@latest module add nuxt-graphql-middleware
 ```
 
 Minimal configuration needed:

--- a/docs/introduction/setup.md
+++ b/docs/introduction/setup.md
@@ -5,7 +5,7 @@
 Install the module using your preferred package manager.
 
 ```sh
-npm install --save nuxt-graphql-middleware
+npx nuxi@latest module add nuxt-graphql-middleware
 ```
 
 ## Step 2: Configure


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
