### PR TITLE
feat: add custom fragment import helpers and remove @graphql-fragment…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@graphql-codegen/typescript": "^4.0.8",
         "@graphql-codegen/typescript-generic-sdk": "^4.0.1",
         "@graphql-codegen/typescript-operations": "^4.2.2",
-        "@graphql-fragment-import/lib": "^3.0.0",
         "@graphql-tools/utils": "^10.2.2",
         "@nuxt/devtools-kit": "1.3.7",
         "@nuxt/kit": "^3.12.2",
@@ -3119,19 +3118,6 @@
       },
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-fragment-import/lib": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@graphql-fragment-import/lib/-/lib-3.0.0.tgz",
-      "integrity": "sha512-s7Zzlr9353bgMlDpq5bWX30fdG4JiR9juSUQihBPd3dmF0m6Y5utiM/pQyo2nR28ueS4wP7G/fpE/YRi+CKI4A==",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "meow": "^7.0.1",
-        "mkdirp": "^1.0.4",
-        "resolve": "^1.17.0",
-        "terminal-link": "^2.1.1",
-        "walk-sync": "^2.2.0"
       }
     },
     "node_modules/@graphql-tools/apollo-engine-loader": {
@@ -7518,15 +7504,13 @@
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "dev": true
     },
-    "node_modules/@types/minimatch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
-    },
     "node_modules/@types/minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag=="
+      "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/node": {
       "version": "20.11.5",
@@ -7539,7 +7523,8 @@
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
-      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+      "dev": true
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
@@ -9460,6 +9445,9 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10109,6 +10097,9 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
       "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "camelcase": "^5.3.1",
         "map-obj": "^4.0.0",
@@ -11681,6 +11672,9 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
       "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "decamelize": "^1.1.0",
         "map-obj": "^1.0.0"
@@ -11696,6 +11690,9 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12181,11 +12178,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/ensure-posix-path": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.1.1.tgz",
-      "integrity": "sha512-VWU0/zXzVbeJNXvME/5EmLuEj2TauvoaTz6aFYK1Z92JCBlDlZ3Gu0tuGR42kpW1754ywTs+QB0g5TP0oj9Zaw=="
     },
     "node_modules/entities": {
       "version": "4.5.0",
@@ -14100,6 +14092,9 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
       "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -14184,7 +14179,8 @@
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
     },
     "node_modules/html-tags": {
       "version": "3.3.1",
@@ -14580,6 +14576,7 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
       "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "dev": true,
       "dependencies": {
         "hasown": "^2.0.0"
       },
@@ -14724,6 +14721,9 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15231,6 +15231,9 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15791,6 +15794,9 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
       "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -15851,38 +15857,6 @@
         "node": ">= 12"
       }
     },
-    "node_modules/matcher-collection": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
-      "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "minimatch": "^3.0.2"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/matcher-collection/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/matcher-collection/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/mdn-data": {
       "version": "2.0.30",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
@@ -15894,41 +15868,6 @@
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
       "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
       "dev": true
-    },
-    "node_modules/meow": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-7.1.1.tgz",
-      "integrity": "sha512-GWHvA5QOcS412WCo8vwKDlTelGLsCGBVevQB5Kva961rmNfun0PCbv5+xta2kUMFJyR8/oWnn7ddeKdosbAPbA==",
-      "dependencies": {
-        "@types/minimist": "^1.2.0",
-        "camelcase-keys": "^6.2.2",
-        "decamelize-keys": "^1.1.0",
-        "hard-rejection": "^2.1.0",
-        "minimist-options": "4.1.0",
-        "normalize-package-data": "^2.5.0",
-        "read-pkg-up": "^7.0.1",
-        "redent": "^3.0.0",
-        "trim-newlines": "^3.0.0",
-        "type-fest": "^0.13.1",
-        "yargs-parser": "^18.1.3"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/meow/node_modules/type-fest": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -16022,6 +15961,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -16054,6 +15994,9 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
       "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "arrify": "^1.0.1",
         "is-plain-obj": "^1.1.0",
@@ -17120,6 +17063,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
       "dependencies": {
         "hosted-git-info": "^2.1.4",
         "resolve": "^1.10.0",
@@ -17131,6 +17075,7 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -18408,7 +18353,8 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
     },
     "node_modules/path-root": {
       "version": "0.1.1",
@@ -19283,6 +19229,9 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -19330,6 +19279,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
       "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
       "dependencies": {
         "@types/normalize-package-data": "^2.4.0",
         "normalize-package-data": "^2.5.0",
@@ -19344,6 +19294,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
       "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
       "dependencies": {
         "find-up": "^4.1.0",
         "read-pkg": "^5.2.0",
@@ -19360,6 +19311,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -19372,6 +19324,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -19383,6 +19336,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -19397,6 +19351,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -19408,6 +19363,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -19416,6 +19372,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
       "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -19469,6 +19426,9 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
@@ -19733,6 +19693,7 @@
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
       "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "dev": true,
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -20450,6 +20411,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
       "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -20458,12 +20420,14 @@
     "node_modules/spdx-exceptions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -20472,7 +20436,8 @@
     "node_modules/spdx-license-ids": {
       "version": "3.0.16",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
-      "integrity": "sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw=="
+      "integrity": "sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==",
+      "dev": true
     },
     "node_modules/speakingurl": {
       "version": "14.0.1",
@@ -20757,6 +20722,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
       "dependencies": {
         "min-indent": "^1.0.0"
       },
@@ -20831,22 +20797,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/supports-hyperlinks": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
-      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
-      "dependencies": {
-        "has-flag": "^4.0.0",
-        "supports-color": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -21040,21 +20995,6 @@
       "resolved": "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",
       "integrity": "sha512-TvmyH7kC6ZVTYkqCODjJIbgvu0FKiwQpZ4D1aknE7xpcDf/qEOB8KZEK5ef2pfbVoiBhNWs3yx4y+ESMtNYmlg==",
       "dev": true
-    },
-    "node_modules/terminal-link": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
-      "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
-      "dependencies": {
-        "ansi-escapes": "^4.2.1",
-        "supports-hyperlinks": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/terser": {
       "version": "5.27.0",
@@ -21298,6 +21238,9 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
       "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -22224,6 +22167,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
@@ -23235,40 +23179,6 @@
       "dev": true,
       "engines": {
         "node": ">=12.17"
-      }
-    },
-    "node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/walk-sync/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/walk-sync/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/watchpack": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "@graphql-codegen/typescript": "^4.0.8",
     "@graphql-codegen/typescript-generic-sdk": "^4.0.1",
     "@graphql-codegen/typescript-operations": "^4.2.2",
-    "@graphql-fragment-import/lib": "^3.0.0",
     "@graphql-tools/utils": "^10.2.2",
     "@nuxt/devtools-kit": "1.3.7",
     "@nuxt/kit": "^3.12.2",

--- a/src/helpers/fragment-import/gather-fragment-imports.ts
+++ b/src/helpers/fragment-import/gather-fragment-imports.ts
@@ -1,0 +1,70 @@
+import {  dirname  } from 'pathe'
+import type { InlineImportsOptions } from './inline-imports'
+import { inlineImportsWithLineToImports } from './inline-imports'
+
+interface FragmentParserGenerator {
+  (source: string): Iterable<{
+    name: {
+      value: string
+    }
+    loc: {
+      filename?: string
+    }
+  }>
+}
+
+interface GatherFragmentImportsOptions extends InlineImportsOptions {
+  /** .graphql source code */
+  source: string
+  /** File path of the source code */
+  sourceLocation: string
+  /** Generator function that is passed source code. Expected to yield objects for each fragment definition */
+  fragmentParserGenerator: FragmentParserGenerator
+}
+
+/**
+ * Helper function to fetch and parse all the direct and transitive imports starting
+ * from the source. Return object is:
+ *
+ * {
+ *     1: {
+ *         FooBar: fragment,
+ *         Bar: fragment
+ *     }
+ * }
+ *
+ */
+export function gatherFragmentImports(gatherFragmentImportsOptions: GatherFragmentImportsOptions): Map<number, Map<string, object>> {
+  const { source, sourceLocation, resolveImport, fragmentParserGenerator, throwIfImportNotFound } = gatherFragmentImportsOptions
+
+  /**
+   * {
+   *     1: {
+   *         FooBar: fragment,
+   *         Bar: fragment
+   *     }
+   * }
+   * @type {Map<number, Map<string, object>>}
+   */
+  const lineToFragmentDefinitions = new Map()
+  const importLinesToInlinedSource = inlineImportsWithLineToImports(source, {
+    resolveOptions: {
+      basedir: dirname(sourceLocation),
+    },
+    resolveImport,
+    throwIfImportNotFound,
+  }).lineToImports
+
+  for (const [lineNumber, { filename, line: source }] of importLinesToInlinedSource) {
+    const fragmentDefinitionsBucket = lineToFragmentDefinitions.get(lineNumber) || new Map()
+    for (const fragment of fragmentParserGenerator(source)) {
+      // Augment the FragmentDefinition by adding the resolved file path inside .loc.filename
+      fragment.loc.filename = filename
+
+      fragmentDefinitionsBucket.set(fragment.name.value, fragment)
+    }
+    lineToFragmentDefinitions.set(lineNumber, fragmentDefinitionsBucket)
+  }
+
+  return lineToFragmentDefinitions
+}

--- a/src/helpers/fragment-import/index.ts
+++ b/src/helpers/fragment-import/index.ts
@@ -1,0 +1,1 @@
+export * from './inline-imports'

--- a/src/helpers/fragment-import/inline-imports.ts
+++ b/src/helpers/fragment-import/inline-imports.ts
@@ -1,0 +1,119 @@
+import { dirname } from 'pathe'
+import * as fs from 'node:fs'
+import { matchImport } from './match-import'
+
+const lineEndingRE = /\r\n|\n/
+
+interface ResolverOptions {
+  [key: string]: unknown
+  basedir?: string
+}
+
+export interface InlineImportsOptions {
+  resolveOptions: ResolverOptions
+  /** This function is used to resolve the path to file for import */
+  resolveImport: (identifier: string, options?: ResolverOptions) => string
+  /** If set to true, throws error if import not found */
+  throwIfImportNotFound?: boolean
+  fs?: typeof import('fs')
+}
+
+interface LineWithInlinedImports {
+  line: string
+  match: boolean
+  lineNumber: number
+  filename?: string
+}
+
+function *linesWithInlinedImportsOf(
+  fileContents: string,
+  inlineImportsOptions: InlineImportsOptions,
+  visited: Set<string>,
+): Generator<LineWithInlinedImports> {
+  const { resolveOptions = {}, resolveImport, fs: nodeFs = fs, throwIfImportNotFound } = inlineImportsOptions
+
+  const { basedir } = resolveOptions
+
+  if (typeof basedir !== 'string') {
+    throw new TypeError('inlineImports requires options.resolverOptions.basedir be set')
+  }
+
+  if (!resolveImport) {
+    throw new TypeError('inlineImports requires options.resolveImport be set')
+  }
+
+  let lineNumber = 0
+  for (const line of fileContents.split(lineEndingRE)) {
+    ++lineNumber
+    const matched = matchImport(line)
+
+    if (matched) {
+      const importIdentifier = matched.importIdentifier
+      let filename: string
+
+      try {
+        filename = resolveImport(importIdentifier, resolveOptions)
+      } catch (err) {
+        if (throwIfImportNotFound === false) {
+          continue
+        }
+
+        throw err
+      }
+
+      if (visited.has(filename)) {
+        continue
+      } else {
+        visited.add(filename)
+      }
+
+      const fragmentSource = nodeFs.readFileSync(filename, 'utf8')
+
+      const line = inlineImportsWithLineToImports(fragmentSource, {
+          resolveImport,
+          resolveOptions: {
+            basedir: dirname(filename),
+          },
+        },
+        visited,
+      )
+
+      yield { line: line.inlineImports, match: true, lineNumber, filename }
+    } else {
+      yield { line, match: false, lineNumber }
+    }
+  }
+}
+
+/**
+ * Returns an object containing the query/fragment with all fragments inlined, as well as the matched imports
+ * (effectively, a combination of both the default `inlineImports` function, and the `lineToImports` utility)
+ */
+export function inlineImportsWithLineToImports(
+  fileContents: string,
+  options: InlineImportsOptions,
+  visited = new Set<string>(),
+) {
+  const inlineImportsResult = []
+  const lineToImports = new Map<number, { filename: string | undefined; line: string }>()
+
+  for (const { line, match, lineNumber, filename } of linesWithInlinedImportsOf(fileContents, options, visited)) {
+    inlineImportsResult.push(line)
+
+    // We're only interested in the inlined import lines, ignore any non-matching lines
+    if (match) {
+      lineToImports.set(lineNumber, { filename, line })
+    }
+  }
+
+  return {
+    inlineImports: inlineImportsResult.join('\n'),
+    lineToImports,
+  }
+}
+
+export const inlineImports = (
+  fileContents: string,
+  options: InlineImportsOptions,
+  visited = new Set<string>(),
+) => inlineImportsWithLineToImports(fileContents, options, visited).inlineImports

--- a/src/helpers/fragment-import/match-import.ts
+++ b/src/helpers/fragment-import/match-import.ts
@@ -1,0 +1,32 @@
+const importSyntaxRE = /^#import (?:'([^']*)'|"([^"]*)")/
+
+export interface ImportMatch {
+  importIdentifier: string
+}
+
+export const matchImport = (value = ''): ImportMatch | undefined => {
+  if (!value) {
+    return undefined
+  }
+
+  if (value.indexOf('#import') !== 0) {
+    // Check if the first line is an import
+    return undefined
+  }
+
+  const matched = value.match(importSyntaxRE)
+
+  if (matched === null) {
+    return undefined
+  }
+
+  const importIdentifierMatch = value.match(importSyntaxRE) || []
+
+  const importIdentifier = importIdentifierMatch[1] ?? importIdentifierMatch[2]
+
+  if (importIdentifier === undefined) {
+    return undefined
+  }
+
+  return { importIdentifier }
+}

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -3,6 +3,8 @@ import { oldVisit } from '@graphql-codegen/plugin-helpers'
 import { resolveFiles, resolveAlias, useLogger } from '@nuxt/kit'
 import { resolve } from 'pathe'
 import type { Resolver } from '@nuxt/kit'
+import { inlineImportsWithLineToImports } from './fragment-import'
+
 // @ts-ignore
 import fragmentImport from '@graphql-fragment-import/lib/inline-imports.js'
 import { validateGraphQlDocuments } from '@graphql-tools/utils'
@@ -51,14 +53,14 @@ export const defaultOptions: ModuleOptions = {
  * Import and inline fragments in GraphQL documents.
  */
 export function inlineFragments(source: string, resolver: any): string {
-  return fragmentImport(source, {
+  return inlineImportsWithLineToImports(source, {
     resolveImport(identifier: string) {
       return resolver(identifier)
     },
     resolveOptions: {
       basedir: './',
     },
-  })
+  }).inlineImports
 }
 
 function validateDeprecated(options: any) {


### PR DESCRIPTION
…-import dependency

- Added new helper modules for inlining and gathering GraphQL fragments:
  - `gather-fragment-imports.ts` to fetch and parse all direct and transitive imports from the source.
  - `inline-imports.ts` to inline import statements within GraphQL files.
  - `match-import.ts` to match import statements in GraphQL files.
- Removed the dependency on `@graphql-fragment-import/lib` by implementing custom fragment import logic.
- Updated `inlineFragments` function to utilize the new `inlineImportsWithLineToImports`.
- Modified `package-lock.json` and `package.json` to reflect these changes.

The new implementation provides more control over the fragment import process and reduces external dependencies.