### PR TITLE
Don't log patterns to the console

### DIFF
--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -107,7 +107,6 @@ export async function autoImportDocuments(
   if (!patterns.length) {
     return Promise.resolve([])
   }
-  console.log({ patterns })
   const files = (
     await resolveFiles(srcResolver(), patterns, {
       followSymbolicLinks: false,


### PR DESCRIPTION
Hello :wave: 

Great module, I'm just annoyed with the `console.log({ patterns })` so I'm suggesting simply removing it.

It could also be configured with a verbose level setting or integrated in Nuxt devtools.