### PR TITLE
fix: remove file extensions from added aliases

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -42,6 +42,10 @@ export default defineNuxtConfig({
     autoImport: false,
   },
 
+  typescript: {
+    typeCheck: 'build',
+  },
+
   future: {
     compatibilityVersion: 4,
   },


### PR DESCRIPTION
Removes file extensions from added aliases to fix issues with resolving of types when using Nuxt's `typescript.typeCheck: true` during build.