### PR TITLE
add operation hash as query param

### DIFF
--- a/docs/advanced/templates.md
+++ b/docs/advanced/templates.md
@@ -164,6 +164,19 @@ function isUserQuery(name: ValidQueryName): boolean {
 }
 ```
 
+## `operation-hashes`
+
+**Alias: `#nuxt-graphql-middleware/operation-hashes`**
+
+Exports the unique hash for every operation.
+
+### Exports
+
+#### `operationHashes`
+
+An object of operation names as key and hashes as values. The hash is calculated
+from the operation source + all fragments used in the fragment.
+
 ## `response`
 
 **Alias: `#nuxt-graphql-middleware/response`**

--- a/src/build/templates/definitions/operation-hashes.ts
+++ b/src/build/templates/definitions/operation-hashes.ts
@@ -1,0 +1,54 @@
+import { defineGeneratorTemplate } from './../defineTemplate'
+import { hash } from 'ohash'
+
+/**
+ * Exports a single opject containing the compiled queries and mutations.
+ */
+export default defineGeneratorTemplate(
+  { path: 'nuxt-graphql-middleware/operation-hashes', virtual: true },
+  (output, helper) => {
+    // In dev mode we don't need to generate the operation hashes.
+    if (helper.isDev) {
+      return `export const operationHashes = {}`
+    }
+
+    const fragmentHashMap: Record<string, string> = {}
+
+    const generatedCode = output.getGeneratedCode()
+    generatedCode.forEach((code) => {
+      if (code.type === 'fragment') {
+        const fragmentHash = hash(code.source)
+        if (code.graphqlName) {
+          fragmentHashMap[code.graphqlName] = fragmentHash
+        }
+      }
+    })
+
+    const lines: string[] = []
+
+    generatedCode.forEach((code) => {
+      if (code.type === 'operation' && code.graphqlName && code.source) {
+        const source = code.source
+        const fragments = code
+          .getGraphQLFragmentDependencies()
+          .map((fragmentName) => {
+            return fragmentHashMap[fragmentName]
+          })
+          .join('')
+        const sourceHash = hash(source + fragments)
+        lines.push(`"${code.graphqlName}": "${sourceHash.substring(0, 10)}"`)
+      }
+    })
+
+    return `export const operationHashes = {
+  ${lines.sort().join(',\n  ')}
+}`
+  },
+  () => {
+    return `
+declare module '#nuxt-graphql-middleware/operation-hashes' {
+  export const operationHashes: Record<string, string>;
+}
+`
+  },
+)

--- a/src/build/templates/index.ts
+++ b/src/build/templates/index.ts
@@ -11,6 +11,7 @@ import ServerOptions from './definitions/server-options'
 import Sources from './definitions/sources'
 import HookDocuments from './definitions/hookDocuments'
 import HookFiles from './definitions/hook-files'
+import OperationHashes from './definitions/operation-hashes'
 
 export const TEMPLATES: ModuleTemplate[] = [
   ClientOptions,
@@ -25,4 +26,5 @@ export const TEMPLATES: ModuleTemplate[] = [
   Sources,
   HookDocuments,
   HookFiles,
+  OperationHashes,
 ]

--- a/src/runtime/composables/nuxtApp.ts
+++ b/src/runtime/composables/nuxtApp.ts
@@ -5,6 +5,7 @@ import { GraphqlMiddlewareCache } from '../helpers/ClientCache'
 import type { GraphqlResponse } from '#nuxt-graphql-middleware/response'
 import { getEndpoint } from '#nuxt-graphql-middleware/helpers'
 import { useNuxtApp, useAppConfig } from '#imports'
+import { operationHashes } from '#nuxt-graphql-middleware/operation-hashes'
 import type { RequestCacheOptions } from './../types'
 
 export function performRequest<T>(
@@ -16,6 +17,7 @@ export function performRequest<T>(
 ): Promise<GraphqlResponse<T>> {
   const state = useGraphqlState()
   const app = useNuxtApp()
+  const config = useAppConfig()
 
   if (!state) {
     console.error(
@@ -23,41 +25,53 @@ export function performRequest<T>(
     )
   }
 
-  // The cache key.
-  const key = `${operation}:${operationName}:${hash(options.params)}`
+  // The unique operation hash that changes whenever any operation source or
+  // fragment changes.
+  const operationHash = operationHashes[operationName]
+
+  const params = {
+    ...(state && state.fetchOptions.params
+      ? (state.fetchOptions.params as any)
+      : {}),
+    ...(options?.params || {}),
+    __gqlh: operationHash,
+  }
+
+  // The cache key that includes the variables, client context and
+  // operation hash.
+  // We only need to build the cache key if actually needed.
+  const cacheKey =
+    import.meta.client &&
+    cacheOptions?.client &&
+    config.graphqlMiddleware.clientCacheEnabled
+      ? `${operation}:${operationName}:${hash(params)}`
+      : undefined
 
   // Try to return a cached query if possible.
-  if (cacheOptions) {
-    const config = useAppConfig()
+  if (import.meta.client && cacheKey) {
     // Handle caching on client.
-    if (
-      import.meta.client &&
-      cacheOptions.client &&
-      config.graphqlMiddleware.clientCacheEnabled
-    ) {
-      if (!app.$graphqlCache) {
-        app.$graphqlCache = new GraphqlMiddlewareCache(
-          config.graphqlMiddleware.clientCacheMaxSize,
-        )
-      }
+    if (!app.$graphqlCache) {
+      app.$graphqlCache = new GraphqlMiddlewareCache(
+        config.graphqlMiddleware.clientCacheMaxSize,
+      )
+    }
 
-      const cached = app.$graphqlCache.get<Promise<GraphqlResponse<T>>>(key)
+    const cached = app.$graphqlCache.get<Promise<GraphqlResponse<T>>>(cacheKey)
 
-      if (cached) {
-        if (import.meta.dev) {
-          cached.then((response) => {
-            if (response.errors.length) {
-              app.callHook('nuxt-graphql-middleware:errors', {
-                operation,
-                operationName,
-                errors: response.errors,
-                stack: Error().stack,
-              })
-            }
-          })
-        }
-        return cached
+    if (cached) {
+      if (import.meta.dev) {
+        cached.then((response) => {
+          if (response.errors.length) {
+            app.callHook('nuxt-graphql-middleware:errors', {
+              operation,
+              operationName,
+              errors: response.errors,
+              stack: Error().stack,
+            })
+          }
+        })
       }
+      return cached
     }
   }
 
@@ -66,6 +80,7 @@ export function performRequest<T>(
     {
       ...(state && state.fetchOptions ? (state.fetchOptions as any) : {}),
       ...options,
+      params,
       method,
     },
   ).then((v) => {
@@ -84,8 +99,8 @@ export function performRequest<T>(
     }
   })
 
-  if (import.meta.client && cacheOptions?.client && app.$graphqlCache) {
-    app.$graphqlCache.set(key, promise)
+  if (import.meta.client && cacheKey && app.$graphqlCache) {
+    app.$graphqlCache.set(cacheKey, promise)
   }
 
   return promise

--- a/test/runtime/composables/__snapshots__/index.test.ts.snap
+++ b/test/runtime/composables/__snapshots__/index.test.ts.snap
@@ -8,7 +8,9 @@ exports[`useGraphqlMutation > Performs a mutation 1`] = `
   "options": {
     "body": undefined,
     "method": "post",
-    "params": {},
+    "params": {
+      "__gqlh": "abc123",
+    },
   },
 }
 `;
@@ -23,7 +25,9 @@ exports[`useGraphqlMutation > Performs a mutation with variables 1`] = `
       "user": "foobar",
     },
     "method": "post",
-    "params": {},
+    "params": {
+      "__gqlh": "abc123",
+    },
   },
 }
 `;
@@ -36,7 +40,9 @@ exports[`useGraphqlMutation > Throws an error for invalid mutation names. 1`] = 
   "options": {
     "body": undefined,
     "method": "post",
-    "params": {},
+    "params": {
+      "__gqlh": undefined,
+    },
   },
 }
 `;
@@ -48,7 +54,9 @@ exports[`useGraphqlQuery > Performs a query 1`] = `
   "errors": [],
   "options": {
     "method": "get",
-    "params": {},
+    "params": {
+      "__gqlh": "abc123",
+    },
   },
 }
 `;
@@ -61,6 +69,7 @@ exports[`useGraphqlQuery > Performs a query with non-string variables 1`] = `
   "options": {
     "method": "get",
     "params": {
+      "__gqlh": "abc123",
       "__variables": "{"numeric":123}",
     },
   },
@@ -75,6 +84,7 @@ exports[`useGraphqlQuery > Performs a query with string variables 1`] = `
   "options": {
     "method": "get",
     "params": {
+      "__gqlh": "abc123",
       "stringVar": "foobar",
     },
   },
@@ -89,6 +99,7 @@ exports[`useGraphqlQuery > Performs a query with string variables 2`] = `
   "options": {
     "method": "get",
     "params": {
+      "__gqlh": "abc123",
       "stringVar": "foobar",
     },
   },
@@ -102,7 +113,9 @@ exports[`useGraphqlQuery > Throws an error for invalid query names. 1`] = `
   "errors": [],
   "options": {
     "method": "get",
-    "params": {},
+    "params": {
+      "__gqlh": undefined,
+    },
   },
 }
 `;

--- a/test/runtime/composables/index.test.ts
+++ b/test/runtime/composables/index.test.ts
@@ -21,6 +21,15 @@ vi.mock('#nuxt-graphql-middleware/helpers', () => {
     },
   }
 })
+
+vi.mock('#nuxt-graphql-middleware/operation-hashes', () => {
+  return {
+    operationHashes: {
+      foobar: 'abc123',
+    },
+  }
+})
+
 vi.mock('#imports', () => {
   return {
     useRuntimeConfig: () => {
@@ -122,6 +131,7 @@ describe('useGraphqlQuery', () => {
           "method": "get",
           "params": {
             "__gqlc_language": "fr",
+            "__gqlh": "abc123",
             "customParam": "yes",
             "stringVar": "foobar",
           },
@@ -170,6 +180,7 @@ describe('useGraphqlMutation', () => {
     expect(result.options.params).toMatchInlineSnapshot(`
       {
         "__gqlc_language": "fr",
+        "__gqlh": "abc123",
         "customParam": "yes",
       }
     `)


### PR DESCRIPTION
Allows cache busting GraphQL query responses after a deployment